### PR TITLE
No, I never said BGL or the Ability API would be coming to SplotchLib, and I am not adding them. They will be part of a separate package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ using SplotchLib;
 - [x] Working API
 - [x] Mod Names
 ### APIs
-- [ ] BGL (Bopl Graphics Lib) (in progress)
-- [ ] Ability API (in progress)
 - [ ] Networking Lib (in progress)
 ### Other Features
 - [x] General utility class


### PR DESCRIPTION
Modnames is stolen.